### PR TITLE
Expose aggregation type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.DS_Store
 .bundle
 .config
 .yardoc

--- a/lib/elasticsearch/dsl/search/aggregation.rb
+++ b/lib/elasticsearch/dsl/search/aggregation.rb
@@ -97,6 +97,12 @@ module Elasticsearch
             {}
           end
         end
+
+
+        def type_name
+          call
+          @value&.name
+        end
       end
 
     end


### PR DESCRIPTION
Backend query builder improvements need to know the type of the constructed aggregation node in order to figure out where to find the relevant buckets/values.

This exposes the type from the value if the aggregation value is a DSL node.