### PR TITLE
Fix issue where BaseAggregationComponent#aggregations does not consistently return nested aggregations

### DIFF
--- a/lib/elasticsearch/dsl/search/aggregation.rb
+++ b/lib/elasticsearch/dsl/search/aggregation.rb
@@ -44,7 +44,13 @@ module Elasticsearch
         #
         def method_missing(name, *args, &block)
           klass = Utils.__camelize(name)
-          if Aggregations.const_defined? klass
+          aggregation_defined = nil
+          begin
+            aggregation_defined = Aggregations.const_defined?(klass)
+          rescue NameError
+            aggregation_defined = false
+          end
+          if aggregation_defined
             @value = Aggregations.const_get(klass).new *args, &block
           elsif @block
             @block.binding.eval('self').send(name, *args, &block)

--- a/lib/elasticsearch/dsl/search/aggregation.rb
+++ b/lib/elasticsearch/dsl/search/aggregation.rb
@@ -90,17 +90,18 @@ module Elasticsearch
         # @return [Hash]
         #
         def to_hash(options={})
-          call
+          @to_hash ||= begin
+            call
 
-          if @value
-            case
-              when @value.respond_to?(:to_hash)
+            if @value
+              if @value.respond_to?(:to_hash)
                 @value.to_hash
               else
                 @value
+              end
+            else
+              {}
             end
-          else
-            {}
           end
         end
 

--- a/lib/elasticsearch/dsl/search/base_aggregation_component.rb
+++ b/lib/elasticsearch/dsl/search/base_aggregation_component.rb
@@ -38,7 +38,13 @@ module Elasticsearch
           #
           def method_missing(name, *args, &block)
             klass = Utils.__camelize(name)
-            if Aggregations.const_defined? klass
+            aggregation_defined = nil
+            begin
+              aggregation_defined = Aggregations.const_defined?(klass)
+            rescue NameError
+              aggregation_defined = false
+            end
+            if aggregation_defined
               @value = Aggregations.const_get(klass).new *args, &block
             elsif @block
               @block.binding.eval('self').send(name, *args, &block)
@@ -66,7 +72,7 @@ module Elasticsearch
           def to_hash(options={})
             call
 
-            unless @hash && @hash[name].respond_to?(:empty?) && !@hash[name].empty?
+            unless @hash && @hash[name] && ! @hash[name].empty?
               args = @args.respond_to?(:to_hash) ? @args.to_hash : @args
               @hash = { name => args }
             end

--- a/lib/elasticsearch/dsl/search/query.rb
+++ b/lib/elasticsearch/dsl/search/query.rb
@@ -38,7 +38,13 @@ module Elasticsearch
         #
         def method_missing(name, *args, &block)
           klass = Utils.__camelize(name)
-          if Queries.const_defined? klass
+          query_defined = nil
+          begin
+            query_defined = Queries.const_defined?(klass)
+          rescue NameError
+            query_defined = false
+          end
+          if query_defined
             @value = Queries.const_get(klass).new *args, &block
           elsif @block
            @block.binding.eval('self').send(name, *args, &block)

--- a/spec/elasticsearch/dsl/search/aggregations/nested_spec.rb
+++ b/spec/elasticsearch/dsl/search/aggregations/nested_spec.rb
@@ -82,5 +82,30 @@ describe Elasticsearch::DSL::Search::Aggregations::Nested do
         expect(search.to_hash).to eq(nested: { path: 'bar' }, aggregations: { min_price: { min: { field: 'bam' } } })
       end
     end
+
+    context 'deeply nested aggregation' do
+
+      let(:search) do
+        described_class.new do
+          path 'foo'
+          aggregation :more_nested do
+            nested do
+              path 'bar'
+              aggregation :min_price do
+                min field: 'baz'
+              end
+            end
+          end
+        end
+      end
+
+      it 'consistently exposes grandchildren aggregations' do
+        search.to_hash
+        expect(search.aggregations.each_value.first.aggregations).to_not be_nil
+        search.to_hash
+        expect(search.aggregations.each_value.first.aggregations).to_not be_nil
+      end
+
+    end
   end
 end


### PR DESCRIPTION
When trying to query an `Aggregation` for `#aggregations`, `elasticsearch-dsl` would return inconsistent results.

On the first call, it would return the fully evaluated aggregations and sub-aggregations, but on a subsequent call, would return nil.

This happens because `Aggregation#call` is called before `#aggregations`, but doesn't actually execute the block if `@_block_called` is true.

If `#to_hash` was called multiple times, the block would not actually be evaluated multiple times and the `Aggregation` instance would show an unevaluated block that would lead to `#aggregations` returning nil`.